### PR TITLE
fix(status): Resolve environment variable bug in status check

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -193,7 +193,6 @@ run_full_update() {
 }
 
 check_status() {
-    local GPU_ENV_FILE="$HOME/.config/rocm-wsl-ai/gpu.env"
     (
     # Check ROCm/PyTorch
     echo "--- System Status ---"
@@ -202,8 +201,6 @@ check_status() {
         # Source in a subshell to not pollute the main script's env
         (
             source "$VENV_PATH/bin/activate"
-            # Explicitly source the GPU env file inside the venv to ensure it's set.
-            if [ -f "$GPU_ENV_FILE" ]; then source "$GPU_ENV_FILE"; fi
 
             PY_VER=$(python3 -c "import torch; print(torch.__version__)" 2>/dev/null || echo "N/A")
             ROCM_OK=$(python3 -c "import torch; print(torch.cuda.is_available())" 2>/dev/null || echo "N/A")
@@ -226,8 +223,6 @@ check_status() {
     # Check ROCm system status
     echo -e "\n--- GPU Information ---"
     if command -v rocminfo &> /dev/null; then
-        # Explicitly source the GPU env file to ensure rocminfo has the override if needed
-        if [ -f "$GPU_ENV_FILE" ]; then source "$GPU_ENV_FILE"; fi
         rocminfo | grep -E 'Agent [0-9]+|Name:|Marketing Name:' | grep -A2 -B1 'Agent' | grep -v -E 'Host|CPU' | head -3
     else
         echo "rocminfo command not found. Is ROCm installed correctly?"


### PR DESCRIPTION
This commit fixes a bug where the "Check Status" menu option would fail with a `'-: No such file or directory'` error and a ROCm assertion failure.

The issue was a complex interaction between subshells, virtual environment activation, and how ROCm tools inherit environment variables.

The fix is two-fold:
1.  `scripts/utils/gpu_config.sh` is updated to write the `gpu.env` file using `export VAR="value"` syntax. This ensures that when the file is sourced, the variables are correctly exported and available to child processes.
2.  The `check_status` function in `menu.sh` has been simplified to rely on the environment variables exported at script startup, removing a redundant and problematic `source` call that was triggering the bug.

Together, these changes ensure that tools like `python` and `rocminfo` receive the necessary `HSA_OVERRIDE_GFX_VERSION` variable, resolving the crash.