### PR TITLE
Fix: Correct whiptail usage for status check

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -36,5 +36,6 @@ if [ -f "$(dirname "${BASH_SOURCE[0]}")/../scripts/utils/gpu_config.sh" ]; then
 
   # Always run detection to set env vars and regenerate the env file.
   # This fixes issues with stale or malformed gpu.env files from previous versions.
-  detect_and_export_rocm_env || warn "GPU auto-detection failed"
+  # Redirecting to stderr to avoid polluting stdout for scripts that source this.
+  detect_and_export_rocm_env >&2 || warn "GPU auto-detection failed"
 fi

--- a/menu.sh
+++ b/menu.sh
@@ -193,41 +193,44 @@ run_full_update() {
 }
 
 check_status() {
-    (
-    # Check ROCm/PyTorch
-    echo "--- System Status ---"
-    if [ -f "$VENV_PATH/bin/activate" ]; then
-        echo "✓ ROCm/PyTorch Environment: INSTALLED"
-        # Source in a subshell to not pollute the main script's env
-        (
-            source "$VENV_PATH/bin/activate"
+    local status_text
+    status_text=$(
+        # Check ROCm/PyTorch
+        echo "--- System Status ---"
+        if [ -f "$VENV_PATH/bin/activate" ]; then
+            echo "✓ ROCm/PyTorch Environment: INSTALLED"
+            # Source in a subshell to not pollute the main script's env
+            (
+                # shellcheck disable=SC1091
+                source "$VENV_PATH/bin/activate"
 
-            PY_VER=$(python3 -c "import torch; print(torch.__version__)" 2>/dev/null || echo "N/A")
-            ROCM_OK=$(python3 -c "import torch; print(torch.cuda.is_available())" 2>/dev/null || echo "N/A")
-            echo "  - PyTorch Version: $PY_VER"
-            echo "  - ROCm Detected by PyTorch: $ROCM_OK"
-        ) || echo "  - PyTorch verification failed."
-    else
-        echo "✗ ROCm/PyTorch Environment: NOT INSTALLED"
-    fi
+                PY_VER=$(python3 -c "import torch; print(torch.__version__)" 2>/dev/null || echo "N/A")
+                ROCM_OK=$(python3 -c "import torch; print(torch.cuda.is_available())" 2>/dev/null || echo "N/A")
+                echo "  - PyTorch Version: $PY_VER"
+                echo "  - ROCm Detected by PyTorch: $ROCM_OK"
+            ) || echo "  - PyTorch verification failed."
+        else
+            echo "✗ ROCm/PyTorch Environment: NOT INSTALLED"
+        fi
 
-    # Check Tools
-    echo -e "\n--- Tool Status ---"
-    [ -f "$COMFYUI_DIR/main.py" ] && echo "✓ ComfyUI: INSTALLED" || echo "✗ ComfyUI: NOT INSTALLED"
-    [ -f "$SDNEXT_DIR/webui.sh" ] && echo "✓ SD.Next: INSTALLED" || echo "✗ SD.Next: NOT INSTALLED"
-    [ -f "$AUTOMATIC1111_DIR/webui.sh" ] && echo "✓ Automatic1111: INSTALLED" || echo "✗ Automatic1111: NOT INSTALLED"
-    [ -f "$INVOKEAI_DIR/invoke.sh" ] && echo "✓ InvokeAI: INSTALLED" || echo "✗ InvokeAI: NOT INSTALLED"
-    [ -d "$FOOOCUS_DIR" ] && echo "✓ Fooocus: INSTALLED" || echo "✗ Fooocus: NOT INSTALLED"
-    [ -d "$FORGE_DIR" ] && echo "✓ SD WebUI Forge: INSTALLED" || echo "✗ SD WebUI Forge: NOT INSTALLED"
+        # Check Tools
+        echo -e "\n--- Tool Status ---"
+        [ -f "$COMFYUI_DIR/main.py" ] && echo "✓ ComfyUI: INSTALLED" || echo "✗ ComfyUI: NOT INSTALLED"
+        [ -f "$SDNEXT_DIR/webui.sh" ] && echo "✓ SD.Next: INSTALLED" || echo "✗ SD.Next: NOT INSTALLED"
+        [ -f "$AUTOMATIC1111_DIR/webui.sh" ] && echo "✓ Automatic1111: INSTALLED" || echo "✗ Automatic1111: NOT INSTALLED"
+        [ -f "$INVOKEAI_DIR/invoke.sh" ] && echo "✓ InvokeAI: INSTALLED" || echo "✗ InvokeAI: NOT INSTALLED"
+        [ -d "$FOOOCUS_DIR" ] && echo "✓ Fooocus: INSTALLED" || echo "✗ Fooocus: NOT INSTALLED"
+        [ -d "$FORGE_DIR" ] && echo "✓ SD WebUI Forge: INSTALLED" || echo "✗ SD WebUI Forge: NOT INSTALLED"
 
-    # Check ROCm system status
-    echo -e "\n--- GPU Information ---"
-    if command -v rocminfo &> /dev/null; then
-        rocminfo | grep -E 'Agent [0-9]+|Name:|Marketing Name:' | grep -A2 -B1 'Agent' | grep -v -E 'Host|CPU' | head -3
-    else
-        echo "rocminfo command not found. Is ROCm installed correctly?"
-    fi
-    ) | whiptail --title "Installation Status" --textbox - 24 78
+        # Check ROCm system status
+        echo -e "\n--- GPU Information ---"
+        if command -v rocminfo &> /dev/null; then
+            rocminfo | grep -E 'Agent [0-9]+|Name:|Marketing Name:' | grep -A2 -B1 'Agent' | grep -v -E 'Host|CPU' | head -3
+        else
+            echo "rocminfo command not found. Is ROCm installed correctly?"
+        fi
+    )
+    whiptail --title "Installation Status" --msgbox "$status_text" 24 78
 }
 
 # --- Menus ---


### PR DESCRIPTION
The 'status' menu option was failing with a '-: No such file or directory' error. This was caused by piping output directly to 'whiptail --textbox -', which is sensitive to unexpected output or file descriptor issues.

This commit fixes the issue by:
1.  Refactoring the `check_status` function in `menu.sh` to first capture the status text into a variable.
2.  Using `whiptail --msgbox` to display the text from the variable, avoiding the fragile pipe mechanism.
3.  Redirecting diagnostic output in `lib/common.sh` to stderr to prevent it from polluting stdout and interfering with piped commands.