### PR TITLE
Fix(scripts): Correct path to common.sh in update_ai_setup.sh

### DIFF
--- a/scripts/utils/update_ai_setup.sh
+++ b/scripts/utils/update_ai_setup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$SCRIPT_DIR/common.sh" ]; then
+if [ -f "$SCRIPT_DIR/../../lib/common.sh" ]; then
     # shellcheck disable=SC1091
-    source "$SCRIPT_DIR/common.sh"
+    source "$SCRIPT_DIR/../../lib/common.sh"
 else
     echo "common.sh not found" >&2; exit 1
 fi


### PR DESCRIPTION
The update script was failing with the error "common.sh not found" because it was looking for the file in the same directory as the script (`scripts/utils`).

This change corrects the path to `common.sh` by adjusting it to point to the `lib` directory at the project root, which is the correct location. The relative path is changed from `$SCRIPT_DIR/common.sh` to `$SCRIPT_DIR/../../lib/common.sh`.