### PR TITLE
Fix(scripts): Correct path and add missing var in update script

### DIFF
--- a/lib/common.sh
+++ b/lib/common.sh
@@ -2,7 +2,7 @@
 # Shared utilities for installer scripts
 set -o pipefail
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; MAGENTA='\033[0;35m'; NC='\033[0m'
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; MAGENTA='\033[0;35m'; CYAN='\033[0;36m'; NC='\033[0m'
 
 log(){ echo -e "${BLUE}[INFO]${NC} $*"; }
 warn(){ echo -e "${YELLOW}[WARN]${NC} $*"; }


### PR DESCRIPTION
This commit addresses two issues in the update script:

1. The `update_ai_setup.sh` script was failing with "common.sh not found" because it was looking for the file in its own directory (`scripts/utils`) instead of the project's `lib` directory. The path has been corrected to `../../lib/common.sh`.

2. After fixing the path, the script failed with "CYAN: unbound variable". This was because the `CYAN` color variable, used for printing messages, was not defined in `lib/common.sh`. This variable has been added to the list of color definitions.