### PR TITLE
refactor: Remove all ROCm 7.0 installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ This is the most important first step. It sets up the core ROCm and PyTorch envi
 
 You will be presented with a choice for the ROCm and PyTorch versions:
 -   **`Latest stable ROCm (recommended) + PyTorch for ROCm 6.1 Nightly`**: This is the recommended option for most users. It installs the latest stable ROCm drivers from the AMD repository and a matching PyTorch nightly build.
--   **`Experimental ROCm 7.0-rc1 + PyTorch for ROCm 7.0 Nightly`**: For advanced users who want to test the latest experimental features.
 
 The script will then handle everything:
 -   Installs the necessary AMD drivers and ROCm stack.
@@ -102,7 +101,6 @@ The script automatically detects the GPU architecture and sets the appropriate `
 If you have a very new or unsupported GPU, you might need to set this variable manually. For the most accurate information, please consult the official AMD documentation.
 
 -   **[Official Compatibility Matrix for ROCm (Latest Stable)](https://rocm.docs.amd.com/en/latest/compatibility/compatibility-matrix.html)**
--   **[Release Notes for ROCm Pre-Releases](https://rocm.docs.amd.com/en/docs-7.0-rc1/preview/release.html)** (For experimental support)
 
 ### A Note on APUs (Ryzen AI)
 

--- a/scripts/install/setup_pytorch_rocm.sh
+++ b/scripts/install/setup_pytorch_rocm.sh
@@ -51,13 +51,9 @@ if [ -f "/opt/rocm/bin/rocminfo" ]; then
 else
     # Determine repository path based on user choice
     ROCM_REPO_PATH=""
-    if [ "$ROCM_VERSION_CHOICE" = "7.0-rc1" ]; then
-        warn "Using experimental ROCm 7.0 RC1 repository."
-        ROCM_REPO_PATH="7.0"
-    else # Default to "latest"
-        log "Using latest stable ROCm repository."
-        ROCM_REPO_PATH="latest"
-    fi
+    # Default to "latest"
+    log "Using latest stable ROCm repository."
+    ROCM_REPO_PATH="latest"
 
     # Add ROCm repository
     if [ ! -f /etc/apt/sources.list.d/rocm.list ]; then
@@ -116,19 +112,13 @@ headline "TASK 5/6: Installing PyTorch Nightly for matching ROCm series + Triton
 
 # Determine PyTorch index based on ROCm choice
 # NOTE: These might need updating as new ROCm versions are released and supported by PyTorch.
-# As of mid-2024, 6.1 is the latest stable series with nightly wheels. 7.0 is experimental.
+# As of mid-2024, 6.1 is the latest stable series with nightly wheels.
 PYTORCH_ROCM_STABLE_SERIES="6.1"
-PYTORCH_ROCM_EXPERIMENTAL_SERIES="7.0"
 
 PYTORCH_ROCM_SERIES=""
-if [ "$ROCM_VERSION_CHOICE" = "7.0-rc1" ]; then
-    PYTORCH_ROCM_SERIES="$PYTORCH_ROCM_EXPERIMENTAL_SERIES"
-    log "Selected experimental ROCm, targeting PyTorch for ROCm ${PYTORCH_ROCM_SERIES}"
-else
-    # For "latest", we target the latest known stable PyTorch series
-    PYTORCH_ROCM_SERIES="$PYTORCH_ROCM_STABLE_SERIES"
-    log "Selected latest stable ROCm, targeting PyTorch for ROCm ${PYTORCH_ROCM_SERIES}"
-fi
+# For "latest", we target the latest known stable PyTorch series
+PYTORCH_ROCM_SERIES="$PYTORCH_ROCM_STABLE_SERIES"
+log "Selected latest stable ROCm, targeting PyTorch for ROCm ${PYTORCH_ROCM_SERIES}"
 log "Targeting ROCm series: ${PYTORCH_ROCM_SERIES}"
 
 PYTORCH_INDEX_URL="https://download.pytorch.org/whl/nightly/rocm${PYTORCH_ROCM_SERIES}"


### PR DESCRIPTION
This commit removes all references to the experimental ROCm 7.0 installation path. The goal is to only offer the latest stable ROCm version to users, simplifying the menu and installation logic.

The following changes were made:
- `menu.sh`: Removed the "Experimental ROCm 7.0-rc1" option from the base installation menu and the driver management menu. The function to fetch RC versions was also removed.
- `scripts/install/setup_pytorch_rocm.sh`: Removed the conditional logic for handling the ROCm 7.0 installation and the corresponding PyTorch experimental series.
- `README.md`: Updated the documentation to remove mentions of the experimental ROCm 7.0 option and the link to pre-release notes.